### PR TITLE
Add username for typed message

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,9 +260,9 @@
         }
       });
 
-      socket.on("chat message", (msg, serverOffset) => {
+      socket.on("chat message", (username, msg, serverOffset) => {
         const item = document.createElement("li");
-        item.textContent = msg;
+        item.textContent = `${username}: ${msg}`;
         messages.appendChild(item);
         window.scrollTo(0, document.body.scrollHeight);
         socket.auth.serverOffset = serverOffset;
@@ -322,9 +322,9 @@
         privateChatMessages.scrollTop = privateChatMessages.scrollHeight;
       });
 
-      socket.on("private chat message", (msg, serverOffsetPrivateChat) => {
+      socket.on("private chat message", (username, msg, serverOffsetPrivateChat) => {
         const item = document.createElement("li");
-        item.textContent = msg;
+        item.textContent = `${username}: ${msg}`;
         privateChatMessages.appendChild(item);
         privateChatMessages.scrollTop = privateChatMessages.scrollHeight;
         socket.auth.serverOffsetPrivateChat = serverOffsetPrivateChat;

--- a/index.js
+++ b/index.js
@@ -97,9 +97,9 @@ io.on("connection", async (socket) => {
       }
       return;
     }
-    // include the offset with the message
-    io.emit("chat message", msg, result.lastID);
-    console.log("message: " + msg);
+    // include the username with the message
+    io.emit("chat message", socket.user.username, msg, result.lastID);
+    console.log("message from", socket.user.username + ":", msg);
     callback();
   });
 
@@ -118,15 +118,9 @@ io.on("connection", async (socket) => {
         } else {
         }
       }
-      io.to(`chat_${chatRoomId}`).emit("private chat message", message);
-      console.log(
-        "private message: " +
-          message +
-          " to chat room " +
-          chatRoomId +
-          " from " +
-          socket.user.username
-      );
+      // include the username with the private message
+      io.to(`chat_${chatRoomId}`).emit("private chat message", socket.user.username, message);
+      console.log("private message from", socket.user.username + ":", message);
       callback();
     }
   );


### PR DESCRIPTION
This pull request includes changes to the chat message handling to include the username with each message. This affects both public and private chat messages, ensuring that the username is displayed along with the message content.
